### PR TITLE
perf: don't packbits twice

### DIFF
--- a/label_rasterizer.py
+++ b/label_rasterizer.py
@@ -21,7 +21,7 @@ def rasterize(encoded_image_data):
 
             buffer += RASTER_COMMAND
             buffer += len(packed_chunk).to_bytes(2, "little")
-            buffer += packbits.encode(chunk)
+            buffer += packed_chunk
         
         yield buffer
 


### PR DESCRIPTION
`packbits.encode(chunk)` was done twice for each chunk

I guess this improves performance quite much (though I didn't benchmark it)